### PR TITLE
Fix an issue when visiting postgres container from login-service container

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+Run_ON_HOST=false

--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,23 @@ start:
 
 down:
 	-docker stop postgres12
-	-docker rm postgres12
-	-docker stop login9
-	-docker rm login9 
+	-docker rm -f postgres12
+	-docker stop login-service
+	-docker rm -f login-service
 
-start-all:
+start-container:
 	-docker stop postgres12
-	-docker rm postgres12
-	-docker stop login9
-	-docker rm login9 
-	bash start.sh 
+	-docker rm -f postgres12
+	-docker stop login-service
+	-docker rm -f login-service
+	-docker network rm login-service-net
+	bash start.sh
+	
+start-host:
+	-docker stop postgres12
+	-docker rm -f postgres12
+	-docker stop login-service
+	-docker rm -f login-service
+	bash start_host.sh
 
 .PHONY: createdb dropdb postgres migratedown migrateup test build run start

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,16 @@ start:
 	go run cmd/main.go
 
 down:
-	docker stop postgres12
-	docker rm postgres12
-	docker stop login9
-	docker rm login9 
+	-docker stop postgres12
+	-docker rm postgres12
+	-docker stop login9
+	-docker rm login9 
 
 start-all:
+	-docker stop postgres12
+	-docker rm postgres12
+	-docker stop login9
+	-docker rm login9 
 	bash start.sh 
 
 .PHONY: createdb dropdb postgres migratedown migrateup test build run start

--- a/api/login.go
+++ b/api/login.go
@@ -18,6 +18,10 @@ type UserLogoutRequest struct {
 	UserName string `json:"user_name" binding:"required"`
 }
 
+func (server *Server) welcome(ctx *gin.Context) {
+	ctx.JSON(http.StatusOK, "Welcome to login service")
+}
+
 func (server *Server) userLogin(ctx *gin.Context) {
 
 	var userReq UserLoginRequest

--- a/api/server.go
+++ b/api/server.go
@@ -16,12 +16,14 @@ type Server struct {
 // Creates new http server and setup routing
 func NewServer(store *db.Store) *Server {
 	server := &Server{store: store}
+
 	router := gin.Default()
 
 	router.POST("/createUser", server.createUser)
 	router.POST("/userLogin", server.userLogin)
 	router.POST("/userLogout", server.userLogout)
 	router.POST("/test", server.AuthCookieMiddleware(), server.TestCookie)
+	router.GET("/", server.welcome)
 
 	router.GET("/protected_route", server.AuthCookieMiddleware(), func(c *gin.Context) {
 		// This route is protected and can only be accessed by authenticated users

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/brianvoe/gofakeit/v6 v6.20.1
 	github.com/gin-gonic/gin v1.9.0
-	github.com/google/uuid v1.3.0
+	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.7
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=

--- a/start_host.sh
+++ b/start_host.sh
@@ -1,7 +1,6 @@
-	docker network create login-service-net
 
 	# use --rm to remove the container once stop
-	docker run --rm --net login-service-net --name postgres12 -p 5430:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -d postgres:12-alpine;
+	docker run --rm --name postgres12 -p 5430:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -d postgres:12-alpine;
 	
 	# add sleep of 3 seconds, otherwise, too fast action might not have enough time for postgres container get ready
 	sleep 3
@@ -11,9 +10,4 @@
 	sleep 3
 	migrate -path database/migration -database "postgresql://root:secret@localhost:5430/loginMicroservice9?sslmode=disable" -verbose up
 
-	docker build -t login9 .;
-
-	# use --rm to remove the container once stop
-	docker run --net login-service-net --name login-service -p 8080:8080 login9
-
-
+	go run -v ./cmd/main.go


### PR DESCRIPTION
The original issue is: the login service could connect to the postgres docker container when login service runs locally, but it fails to connect if it runs in login-service container.

1. After searching Google, a similar issue is mentioned in this post: https://www.tutorialworks.com/container-networking/. 
When we want one container to visit another container, it is better to create a user-defined bridge network, instead of using the default bridge network (for the default network, we have to use address to visit other container). 

After creating the user-defined network named "login-service-net", when login service runs in the container, "dbSource" variable will set "postgres12" as hostname. When login service runs on host machine for the convenience of debugging, "dbSource" variable will be set to "localhost". This change happens in cmd/main.go

2. Also add a file .env and developer needs to toggle it to decide if login-service is running in host machine or container.

3. Makefile is also updated. Now, "make start-host" and "make start-container" are separate because the former command does not need to create user-defined bridge network.

4. For "subscription" and "playlist" micro-services, they do not have this step because they are using docker-compost.yaml and in .yaml, the "depends-on" section will create a user-defined bridge network automatically.